### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,10 @@ Depends:
     Rcpp (>= 0.12.0),
     methods
 License: GPL (>= 3)
-LinkingTo: StanHeaders (>= 2.18.0), rstan (>= 2.18.1), BH (>= 1.66.0), Rcpp (>=
+LinkingTo: StanHeaders (>= 2.26.0), rstan (>= 2.26.0), BH (>= 1.66.0), Rcpp (>=
     0.12.0), RcppEigen (>= 0.3.3.3.0), RcppParallel (>= 5.0.1)
 Imports:
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     RcppParallel (>= 5.0.1),
     rstantools (>= 2.1.1),
     sqldf (>= 0.4),

--- a/inst/stan/idem.stan
+++ b/inst/stan/idem.stan
@@ -19,8 +19,8 @@ functions {
   }
 
   real cond_lpdf(vector ymis, vector yobs, matrix coef,
-                 int ny, real[] mu, real[] sigma, int[] imis, int[] inx,
-                 int assumenormal, int nres, matrix residual, real[] h) {
+                 int ny, array[] real mu, array[] real sigma, array[] int imis, array[] int inx,
+                 int assumenormal, int nres, matrix residual, array[] real h) {
     real rst;
     real cmu;
     real csigma;
@@ -65,20 +65,20 @@ data {
   vector[NX]            X;    //covariates
   matrix[NY, NX+3]      COEF; //coefficents 1st column is sigma
 
-  int<lower=0, upper=1> IMIS[NY];
-  int<lower=1>          INX[NY];
+  array[NY] int<lower=0, upper=1> IMIS;
+  array[NY] int<lower=1>          INX;
 
   //residuals
   int<lower=0, upper=1> ASSUMENORMAL;
   int<lower=1>          NRES;
   matrix[NRES,NY]       RESIDUAL;
-  real                  H[NY]; 
+  array[NY] real                  H; 
 }
 
 transformed data {
   int<lower = 0> NMIS;
-  real MU[NY];
-  real SIGMA[NY];
+  array[NY] real MU;
+  array[NY] real SIGMA;
 
   NMIS = NY - NOBS;
   for (i in 1:NY) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
